### PR TITLE
Update/facebook sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Changelog
 
+## **1.2.1**
+- Update of Facebook SDK which fixes issue with crash on Android 12
+
 ## **1.2.0**
 - Migration from jCenter to Maven Central 🎉
 - ‼️ Important ‼️ groupId has changed. New groupId is `io.github.ackeecz`.

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    api 'com.facebook.android:facebook-login:9.0.0'
+    api 'com.facebook.android:facebook-login:11.3.0'
 }
 
 ext {

--- a/lib.properties
+++ b/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.0
+VERSION_NAME=1.2.1
 VERSION_CODE=1
 GROUP=io.github.ackeecz
 SITE_URL=https://github.com/AckeeCZ/rx-social-login


### PR DESCRIPTION
Update Facebook Login SDK - the one currently used doesn't set mutability flags for `PendingIntent`s which causes crashes on Android 12 devices